### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python "

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ CIS 120 fall 2019
 * Calling functions with keyword arguments
 * conditional checks
 
+[![Run on Repl.it](https://repl.it/badge/github/JoshPorterDev/War)](https://repl.it/github/JoshPorterDev/War)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@JoshPorterDev/War).